### PR TITLE
doc: Fixes and adaptions to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ After installing CUDA:
   - sudo apt install -y libevent-dev
   - sudo apt install -y libzmq5
 
-- download the executables (qubitcoind, qubitcoin-cli, qubitcoin-miner from [superquantum](https://superquantum.io/qubitcoin.html or build your own [see instructions below])
+- download the executables (qubitcoind, qubitcoin-cli, qubitcoin-miner from [superquantum](https://superquantum.io/qubitcoin) or build your own [see instructions below])
 - locate the packages in a specified directory (e.g. ~/ or /home/username)
   - [Windows/WSL] copy files from download folder to /home: cp /mnt/c/Users/aardp/Downloads/qubitcoin ~/
 - may need to change file format for the executables: chmod +x _file_name_ (e.g chmod +x qubitcoind)

--- a/README.md
+++ b/README.md
@@ -51,27 +51,27 @@ After installing CUDA:
 
 - install libzmq5 and libevent
 
-  - sudo apt update
-  - sudo apt install -y libevent-dev
-  - sudo apt install -y libzmq5
+  - `sudo apt update`
+  - `sudo apt install -y libevent-dev`
+  - `sudo apt install -y libzmq5`
 
-- download the executables (qubitcoind, qubitcoin-cli, qubitcoin-miner from [superquantum](https://superquantum.io/qubitcoin) or build your own [see instructions below])
-- locate the packages in a specified directory (e.g. ~/ or /home/username)
-  - [Windows/WSL] copy files from download folder to /home: cp /mnt/c/Users/aardp/Downloads/qubitcoin ~/
-- may need to change file format for the executables: chmod +x _file_name_ (e.g chmod +x qubitcoind)
+- download the executables (`qubitcoind`, `qubitcoin-cli`, `qubitcoin-miner` from [superquantum](https://superquantum.io/qubitcoin) or build your own [see instructions below])
+- locate the packages in a specified directory (e.g. `~/` or `/home/username`)
+  - [Windows/WSL] copy files from download folder to /home: `cp /mnt/c/Users/aardp/Downloads/qubitcoin ~/`
+- may need to change file format for the executables: `chmod +x _file_name_` (e.g chmod +x qubitcoind)
 - run the node executable (aka bitcoin daemon) qubitcoind (from the directory where the packages are located):<br>
-  sudo ./qubitcoind -rpcuser=test -rpcpassword=test -bind="0.0.0.0:42069" -addnode="73.47.180.210:42069" -reindex<br>
+  `sudo ./qubitcoind -rpcuser=test -rpcpassword=test -bind="0.0.0.0:42069" -addnode="73.47.180.210:42069" -reindex`<br>
   _here we specified the ip address of one of the available nodes_
 - start/add a wallet (command line interface) in a separate terminal window [do it once when you create wallet for the first time]:<br>
-  - sudo ./qubitcoin-cli -rpcuser=test -rpcpassword=test createwallet {wallet_name}
-  - sudo ./qubitcoin-cli -rpcuser=test -rpcpassword=test getnewaddress
-  - sudo ./qubitcoin-cli -rpcuser=test -rpcpassword=test loadwallet {wallet_name}
+  - `sudo ./qubitcoin-cli -rpcuser=test -rpcpassword=test createwallet {wallet_name}`
+  - `sudo ./qubitcoin-cli -rpcuser=test -rpcpassword=test getnewaddress`
+  - `sudo ./qubitcoin-cli -rpcuser=test -rpcpassword=test loadwallet {wallet_name}`
 - launch a miner using the wallet address acquired earlier <br>
-  sudo ./qubitcoin-miner --algo qhash -t 1 --url http://127.0.0.1:8332 --userpass test:test --coinbase-addr {address from previous step}
+  `sudo ./qubitcoin-miner --algo qhash -t 1 --url http://127.0.0.1:8332 --userpass test:test --coinbase-addr {address from previous step}`
 
 After that the mining process should begin. The node and miner can be terminated by ctr+c.<br>
 Check peer-info:<br>
-sudo ./qubitcoin-cli -rpcuser=test -rpcpassword=test getpeerinfo
+`sudo ./qubitcoin-cli -rpcuser=test -rpcpassword=test getpeerinfo`
 
 ## Bitcoin Fork
 


### PR DESCRIPTION
Small fixes to README.md

1.  Fix link to superquantum. Old link with `.html` suffix was invalid. Also adds missing parenthesis
2.  Adds `code annotations` for better readability in the How-To section of README.md